### PR TITLE
Fix repeated SIGINT signals

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -31,7 +31,15 @@ if (process.platform === 'win32') {
     });
 }
 
+let sigintCalled = false;
+
 process.on('SIGINT', async () => {
+  if (sigintCalled) {
+    logger.warn('SIGINT caught twice, skipping');
+    return;
+  }
+  sigintCalled = true;
+
   await Server.getInstance().stop();
   process.exit(0);
 });


### PR DESCRIPTION
How to replicate the error:
1. Start the server
2. Add a random user with a mutation (e.g. via Playground)
3. Errors appear on the console (attempts to close unexisting database connections).

With this fix, output is as follows:

2020-12-16 14:39:02:152 INFO     Server started and listening at :: on port 8080
2020-12-16 14:39:09:978 INFO     Created user aca03207-ada2-4374-aa95-e00b7a893f30
^C2020-12-16 14:39:11:237 INFO   Database disconnected
2020-12-16 14:39:11:239 WARN     SIGINT caught twice, skipping